### PR TITLE
Add paper link to header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,8 +23,8 @@
             <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
-          <a class="page-link"
           <a class="page-link" href="https://docs.flashinfer.ai/">Documentation</a>
+          <a class="page-link" href="https://arxiv.org/abs/2501.01005">Paper</a>
           <a class="page-link" href="https://github.com/flashinfer-ai/flashinfer">Github</a>
         </div>
       </nav>


### PR DESCRIPTION
This commit adds the paper link (https://arxiv.org/abs/2501.01005) to the website header.